### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.aifeii.qrcode.tools'
 version '0.1.0'
 
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()
@@ -25,14 +25,28 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+compileSdkVersion 30
+
+    namespace "com.aifeii.qrcode.tools"
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
     defaultConfig {
         minSdkVersion 16
     }
+
+
 }
 
 dependencies {
@@ -41,3 +55,5 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
+
+


### PR DESCRIPTION
Adds namespace to build.gradle 

In Flutter, the requirement to specify a namespace for Android plugins arises due to changes in the Android Gradle Plugin (AGP) version 8.0.0 and above, which mandates the explicit declaration of a namespace.